### PR TITLE
Fix matching for fenix beta versions

### DIFF
--- a/src/ac-version-for-fenix-beta.py
+++ b/src/ac-version-for-fenix-beta.py
@@ -65,7 +65,7 @@ def get_current_ac_version_in_fenix(fenix_repo, release_branch_name):
 
 
 def is_beta_version(version):
-    return re.compile(r'\d+.0.0-beta.\d+', re.MULTILINE).match(version)
+    return re.compile(r'\d+.0b\d+', re.MULTILINE).match(version)
 
 
 def is_fenix_beta_branch(fenix_repo, release_branch_name):


### PR DESCRIPTION
In bug 1777255 (https://github.com/mozilla-mobile/fenix/pull/25946)
fenix switched from using XXX.0.0-beta.Y to XXX.0bY for beta builds, but
this wasn't updated so sync-strings in A-C stopped working.