### PR TITLE
No issue - Use the new version format for AC version validation

### DIFF
--- a/src/ac-version-for-fenix-beta.py
+++ b/src/ac-version-for-fenix-beta.py
@@ -22,8 +22,8 @@ from github import Github, InputGitAuthor, enable_console_debug_logging
 #
 
 def validate_ac_version(v):
-    """Validate that v is in the format of 63.0.2. Returns v or raises an exception."""
-    if not re.match(r"^\d+\.\d+\.\d+$", v):
+    """Validate that v is in the format of 109.0b1. Returns v or raises an exception."""
+    if not re.match(r"^\d+\.0b\d+$", v):
         raise Exception(f"Invalid AC version format {v}")
     return v
 


### PR DESCRIPTION
https://github.com/mozilla-mobile/firefox-android/actions/runs/3700501994/jobs/6268977787

```
Traceback (most recent call last):
  File "/usr/src/app/ac-version-for-fenix-beta.py", line 123, in <module>
    current_ac_version = get_current_ac_version_in_fenix(fenix_repo, branch_name)
  File "/usr/src/app/ac-version-for-fenix-beta.py", line 6[4](https://github.com/mozilla-mobile/firefox-android/actions/runs/3700501994/jobs/6268977787#step:4:5), in get_current_ac_version_in_fenix
    return match_ac_version_in_fenix(content_file.decoded_content.decode('utf8'))
  File "/usr/src/app/ac-version-for-fenix-beta.py", line [5](https://github.com/mozilla-mobile/firefox-android/actions/runs/3700501994/jobs/6268977787#step:4:6)[7](https://github.com/mozilla-mobile/firefox-android/actions/runs/3700501994/jobs/6268977787#step:4:8), in match_ac_version_in_fenix
    return validate_ac_version(match[1])
  File "/usr/src/app/ac-version-for-fenix-beta.py", line 27, in validate_ac_version
    raise Exception(f"Invalid AC version format {v}")
Exception: Invalid AC version format 10[9](https://github.com/mozilla-mobile/firefox-android/actions/runs/3700501994/jobs/6268977787#step:4:10).0b1
```

We're using the new AC version format now. So, we need to update the validation.
